### PR TITLE
Added ext-curl to required section of composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "description": "Official SendinBlue provided API V2 wrapper",
     "license": "MIT",
     "require": {
-        "php": ">=5.3"
+        "php": ">=5.3",
+        "ext-curl": "*"
     },
     "autoload": {
         "psr-0": { "Sendinblue": "src/" }


### PR DESCRIPTION
It's better to require curl extension in composer, rather than in readme doc